### PR TITLE
fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ var servers = mqttServer({
   },
   emitEvents: true // default
 }, function(client){
-  client.connack({
-    returnCode: 0
+  client.on('connect', function(){
+    client.connack({
+      returnCode: 0
+    });
   });
 });
 


### PR DESCRIPTION
The example in the README was not working.
It was missing a line that wraps the `client.connack` call.